### PR TITLE
Upgrade react peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.2 - 2017-01-04
+* Update : `package.json` upgrade React peer dependency to ^15.3.0 (from ~15.3.0)
+
 # 2.0.1 - 2016-11-21
 * Add : Handle non web-browser environments
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-google-maps-loader",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "React HOC to use google maps services into your react applications",
   "repository": {
     "type": "git",
@@ -28,7 +28,7 @@
     "little-loader": "~0.1.0"
   },
   "peerDependencies": {
-    "react": "~15.3.0"
+    "react": "^15.3.0"
   },
   "devDependencies": {
     "babel-core": "~6.14.0",


### PR DESCRIPTION
I don't see any reason this peer dependency could be much wider than ^15.3.0 as there are no "new" features used here.