### PR TITLE
render component even when google maps is not loaded yet

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,9 +56,7 @@ const GoogleMapsLoader = (TargetComponent, params) => (
 
     render() {
       const {googleMaps} = this.state
-      return googleMaps
-        ? <TargetComponent googleMaps={googleMaps} {...this.props} />
-        : null
+      return <TargetComponent googleMaps={googleMaps} {...this.props} />
     }
   }
 )


### PR DESCRIPTION
I like your implementation, though I've encountered one problem over and over again.

Currently `GoogleMapsLoader` is deciding what to do when `googleMaps` is not loaded yet.
This might be just fine in many cases, but often it'd be much more practical to have the `< TargetComponent />` decide what to do.

e.g.

```
const TargetComponent = ({ googleMaps }) => {
  if(! googleMaps) {
    return <Spinner /> // you could still can just return `null`
  } else {
    /* code */
  }
}
```

For that reason I removed the logic that returns `null` instead of rendering the TargetComponent. Now it would just render the TargetComponent no matter what, and let it decide how to handle the loading period.