### PR TITLE
Allow Custom Loading State

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
 
 ## Demo Development Server
 
-- `yarn start` will run a development server with the component's demo app at [http://localhost:3000](http://localhost:3000) with hot module reloading.
+- `yarn start` will run a development server with the component's demo app at [http://localhost:1190](http://localhost:1190) with hot module reloading.
 
 ## Linting
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ https://unpkg.com/react-google-maps-loader/dist/react-google-maps-loader.min.js.
 
 ## Usage
 
+### Load Map Only
+
+This renders when the map is ready, with no loading state.
+
 ```javascript
 import React from "react"
 import ReactGoogleMapLoader from "react-google-maps-loader"
@@ -42,6 +46,49 @@ const App = () =>
         )}
     />
 ```
+
+### Show Loading State
+
+You can show a custom loading state while the user is still online by using the error values.
+
+#### Error Values
+
+* `[String] Network Error` - if the user us offline.
+
+* `[String] SDK Authentication Error` - if there is a problem loading Google maps due to incorrect keys, going over quota or one of the errors listed in the [Error Messages Documentation](https://developers.google.com/maps/documentation/javascript/error-messages).
+
+* `undefined` - map loaded correctly.
+
+```js
+import React from "react"
+import ReactGoogleMapLoader from "react-google-maps-loader"
+
+const App = () =>
+  <ReactGoogleMapLoader
+    params={{
+        key: YOUR_API_KEY, // Define your api key here
+        libraries: "places,geometry", // To request multiple libraries, separate them with a comma
+    }}
+    render={(googleMaps, error) =>
+        googleMaps ? (
+            <div>
+                {/*Show a custom error if SDK Authentication Error. See N/B 2 below.*/}
+                {error ? error : "Google Maps is loaded !"}
+            </div>
+        )   :   (
+            <div>
+                {/*Check for network error so loading state ends if user lost connection.*/}
+                {error === "Network Error" ? <p>{error}</p> : <p>isLoading...</p>}
+            </div>
+        )
+    }/>
+```
+
+N/B:
+
+1. The Google Maps API does not provide errors in the callback but logs them to the console. We grouped all Google Maps errors not related to network connectivity as `SDK Authentication Error`. Check the console if you get this.
+
+2. `googleMaps` always loads as long as there is no `Network Error` and the previous state is not cached. So, handle `SDK Authentication Errors` (See 1. above) in the `googleMaps` part of the conditional rendering as shown in the code above.
 
 ## Demo
 

--- a/demo/src/routes.js
+++ b/demo/src/routes.js
@@ -14,17 +14,28 @@ const routes = [
         <div dangerouslySetInnerHTML={{__html: demoHtml}} />
         <ReactGoogleMapLoader
           params={{
-            key: "AIzaSyCI3cDduwloUnVSfREo-6wuRYTMjOHcQjc",
+            //key: "AIzaSyCI3cDduwloUnVSfREo-6wuRYTMjOHcQjc",
+            key: "AIzaSyDVfAMGWXNTAL-TeCybpvndAFxDOZiSew",
             libraries: "places,geometry",
           }}
-          render={googleMaps =>
-            googleMaps && (
+          render={(googleMaps, error) =>
+            /*eslint-disable no-console, no-undef */
+            googleMaps ? (
               <div style={{height: "300px"}}>
+                {error && error}
                 <ReactGoogleMap
                   googleMaps={googleMaps}
                   center={{lat: 43.604363, lng: 1.443363}}
                   zoom={8}
                 />
+              </div>
+            ) : (
+              <div>
+                {error === "Network Error" ? (
+                  <p>{error}</p>
+                ) : (
+                  <p>isLoading...</p>
+                )}
               </div>
             )}
         />

--- a/demo/src/routes.js
+++ b/demo/src/routes.js
@@ -14,12 +14,10 @@ const routes = [
         <div dangerouslySetInnerHTML={{__html: demoHtml}} />
         <ReactGoogleMapLoader
           params={{
-            //key: "AIzaSyCI3cDduwloUnVSfREo-6wuRYTMjOHcQjc",
-            key: "AIzaSyDVfAMGWXNTAL-TeCybpvndAFxDOZiSew",
+            key: "AIzaSyCI3cDduwloUnVSfREo-6wuRYTMjOHcQjc",
             libraries: "places,geometry",
           }}
           render={(googleMaps, error) =>
-            /*eslint-disable no-console, no-undef */
             googleMaps ? (
               <div style={{height: "300px"}}>
                 {error && error}

--- a/src/index.js
+++ b/src/index.js
@@ -9,18 +9,21 @@ class GoogleMapsLoader extends React.Component {
 
     this.state = {
       googleMaps: null,
+      error: null,
     }
   }
 
   componentWillMount() {
     const {params} = this.props
-    loadGoogleMapsSdk(params, googleMaps => this.setState({googleMaps}))
+    loadGoogleMapsSdk(params, (googleMaps, error) =>
+      this.setState({googleMaps, error})
+    )
   }
 
   render() {
-    const {googleMaps} = this.state
+    const {googleMaps, error} = this.state
     const {render} = this.props
-    return render(googleMaps)
+    return render(googleMaps, error)
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ class GoogleMapsLoader extends React.Component {
 
   componentWillMount() {
     const {params} = this.props
-    loadGoogleMapsSdk(params, (googleMaps, error) =>
+    loadGoogleMapsSdk(params, ({googleMaps, error}) =>
       this.setState({googleMaps, error})
     )
   }

--- a/src/loadGoogleMapsSdk/index.js
+++ b/src/loadGoogleMapsSdk/index.js
@@ -9,31 +9,38 @@ const LOADED = 2
 const queue = []
 let state = NOT_LOADED
 let sdk
+let loadError
 
 function loadGoogleMapsSdk(params, callback) {
   if (typeof window !== "undefined") {
+    window.gm_authFailure = () => {
+      loadError = "SDK Authentication Error"
+      callback(sdk, loadError)
+    }
+
     if (state === LOADED) {
-      callback(sdk)
+      callback(sdk, loadError)
     } else if (state === LOADING) {
       queue.push(callback)
     } else if (window.google != null && window.google.maps != null) {
       state = LOADED
       sdk = window.google.maps
-      callback(sdk)
+      callback(sdk, loadError)
     } else {
       state = LOADING
       queue.push(callback)
 
       load(`${GOOGLE_MAP_PLACES_API}?${qs.stringify(params)}`, err => {
         if (err) {
-          throw new Error("Unable to load Google Map SDK")
+          loadError = "Network Error"
+          callback(sdk, loadError)
+        } else {
+          state = LOADED
+          sdk = window.google.maps
         }
 
-        state = LOADED
-        sdk = window.google.maps
-
         while (queue.length > 0) {
-          queue.pop()(sdk)
+          queue.pop()(sdk, loadError)
         }
       })
     }

--- a/src/loadGoogleMapsSdk/index.test.js
+++ b/src/loadGoogleMapsSdk/index.test.js
@@ -4,6 +4,11 @@ const params = {
   libraries: "places,geometry",
 }
 
+const fakeParams = {
+  key: "1234555666",
+  libraries: "places,geometry",
+}
+
 beforeAll(() => {
   const script = document.createElement("script")
   document.body.appendChild(script)
@@ -22,5 +27,16 @@ describe("loadGoogleMapsSdk", () => {
     }
 
     loadGoogleMapsSdk(params, callback)
+  })
+
+  test("Returns Google Maps Authntication Error", done => {
+    function callback(googleMaps, error) {
+      window.setTimeout(() => {
+        expect(error).toEqual("SDK Authentication Error")
+      }, 1000)
+      done()
+    }
+
+    loadGoogleMapsSdk(fakeParams, callback)
   })
 })

--- a/src/loadGoogleMapsSdk/index.test.js
+++ b/src/loadGoogleMapsSdk/index.test.js
@@ -16,7 +16,7 @@ beforeAll(() => {
 
 describe("loadGoogleMapsSdk", () => {
   test("Loads places and geometry libraries", done => {
-    function callback(googleMaps) {
+    function callback({googleMaps}) {
       expect(googleMaps).toEqual(
         expect.objectContaining({
           places: expect.anything(),
@@ -30,7 +30,7 @@ describe("loadGoogleMapsSdk", () => {
   })
 
   test("Returns Google Maps Authntication Error", done => {
-    function callback(googleMaps, error) {
+    function callback({error}) {
       window.setTimeout(() => {
         expect(error).toEqual("SDK Authentication Error")
       }, 1000)
@@ -38,5 +38,16 @@ describe("loadGoogleMapsSdk", () => {
     }
 
     loadGoogleMapsSdk(fakeParams, callback)
+  })
+
+  test("Returns Network Error", done => {
+    function callback({error}) {
+      window.setTimeout(() => {
+        expect(error).toBe("Network Error")
+      }, 1000)
+      done()
+    }
+
+    loadGoogleMapsSdk(null, callback)
   })
 })


### PR DESCRIPTION
The error state is provied as a property of the render method. The error
is either one of 'Network Error' for connectivity problems or 'SDK Authentication Error'
for Google Maps errors.

You can set a custom loading state conditionally if there is no
googleMaps loaded and if there is no network error.

If there is an SDK Authentication error, googleMaps will still be
loaded, but with an error which you can show in the googleMaps
conditional block.

Refer to README file.