### PR TITLE
Use callback param instead of script onload

### DIFF
--- a/src/loadGoogleMapsSdk/index.js
+++ b/src/loadGoogleMapsSdk/index.js
@@ -46,6 +46,9 @@ function loadGoogleMapsSdk(params, callback) {
           if (err) {
             error = err ? "Network Error" : null
             state = LOADED
+            while (queue.length > 0) {
+              queue.pop()({googleMaps, error})
+            }
           }
         }
       )

--- a/src/loadGoogleMapsSdk/index.js
+++ b/src/loadGoogleMapsSdk/index.js
@@ -11,7 +11,8 @@ let state = NOT_LOADED
 let googleMaps = null
 let error = null
 
-function loadGoogleMapsSdk(params, callback) {
+// NOTE: the third argument is a testing utility.
+function loadGoogleMapsSdk(params, callback, baseUrl = GOOGLE_MAP_PLACES_API) {
   if (typeof window !== "undefined") {
     window.gm_authFailure = () => {
       callback({googleMaps, error: "SDK Authentication Error"})
@@ -38,7 +39,7 @@ function loadGoogleMapsSdk(params, callback) {
       queue.push(callback)
 
       load(
-        `${GOOGLE_MAP_PLACES_API}?${qs.stringify({
+        `${baseUrl}?${qs.stringify({
           callback: "onGoogleMapsLoad",
           ...params,
         })}`,


### PR DESCRIPTION
Fixes #26 

## Motivation
See #26. This work is a bit speculative - I haven't verified that the failure mode that I described in #26 is actually what's happening, but this is the approach recommended by the [google maps docs](https://developers.google.com/maps/documentation/javascript/tutorial#Loading_the_Maps_API).

## Changes
* Add `onGoogleMapsLoad` callback to `window` at the beginning of load
* Put callback logic into that callback
* Add callback parameter to `params` object, placing it before the destructuring so that a consumer could override it if they wanted to for whatever reason
* Only run script load callback if it's an error

## Testing
Code review. See that tests pass. Tell me if there's another test that you'd like to see.