### PR TITLE
Update peer dependencies to support React 17+

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "react-test-renderer": "^16.13.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   }
 }


### PR DESCRIPTION
I saw the package had an update 7 months ago. It's working with React 17+ for us, but it would be great to remove install errors/warnings with the peer dependency when we do that. :pray: